### PR TITLE
Fix audit shipping config so that we do not have it duplicated

### DIFF
--- a/docker-image/v1.3/debian-datadog/conf/fluent.conf
+++ b/docker-image/v1.3/debian-datadog/conf/fluent.conf
@@ -26,20 +26,3 @@
    dd_tags "#{ENV['DATADOG_TAGS'] || 'fluentd:fluentd'}"
    dd_sourcecategory "#{ENV['DATADOG_SOURCE_CATEGORY'] || 'fluentd'}"
 </match>
-
-<source>
-  @type tail
-  format json
-  time_key time
-  path /var/log/kube-apiserver-audit.log
-  pos_file /var/log/kube-apiserver-audit.log.pos
-  time_format %Y-%m-%dT%H:%M:%S.%NZ
-  tag audit
-  read_from_head false
-</source>
-
-<match audit.**>
-  @type sumologic
-  endpoint "#{ENV['SUMOLOGIC_HOST']}"
-  log_format json
-</match>

--- a/docker-image/v1.3/debian-datadog/conf/kubernetes.conf
+++ b/docker-image/v1.3/debian-datadog/conf/kubernetes.conf
@@ -170,7 +170,7 @@
   multiline_flush_interval 5s
   path /var/log/kubernetes/kube-apiserver-audit.log
   pos_file /var/log/kube-apiserver-audit.log.pos
-  tag kube-apiserver-audit
+  tag audit
   <parse>
     @type multiline
     format_firstline /^\S+\s+AUDIT:/
@@ -184,6 +184,12 @@
     time_format %Y-%m-%dT%T.%L%Z
   </parse>
 </source>
+
+<match audit.**>
+  @type sumologic
+  endpoint "#{ENV['SUMOLOGIC_HOST']}"
+  log_format json
+</match>
 
 <filter kubernetes.**>
   @type kubernetes_metadata

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -368,20 +368,3 @@
 </match>
 
 <% end %>
-
-<source>
-  @type tail
-  format json
-  time_key time
-  path /var/log/kube-apiserver-audit.log
-  pos_file /var/log/kube-apiserver-audit.log.pos
-  time_format %Y-%m-%dT%H:%M:%S.%NZ
-  tag audit
-  read_from_head false
-</source>
-
-<match audit.**>
-  @type sumologic
-  endpoint "#{ENV['SUMOLOGIC_HOST']}"
-  log_format json
-</match>

--- a/templates/conf/kubernetes.conf.erb
+++ b/templates/conf/kubernetes.conf.erb
@@ -227,7 +227,7 @@
   multiline_flush_interval 5s
   path /var/log/kubernetes/kube-apiserver-audit.log
   pos_file /var/log/kube-apiserver-audit.log.pos
-  tag kube-apiserver-audit
+  tag audit
 <% if is_v1 %>
   <parse>
     @type multiline
@@ -254,6 +254,12 @@
   time_format %FT%T.%L%Z
 <% end %>
 </source>
+
+<match audit.**>
+  @type sumologic
+  endpoint "#{ENV['SUMOLOGIC_HOST']}"
+  log_format json
+</match>
 
 <filter kubernetes.**>
   @type kubernetes_metadata


### PR DESCRIPTION
I had tested the file fluentd.conf in isolation. That made me miss the fact that kubernetes.conf already has audit config.